### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/web/gin/m3u.go
+++ b/web/gin/m3u.go
@@ -4,12 +4,40 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"strings"
 )
 
 func M3U(ctx *gin.Context) {
-	js, err := json.MarshalIndent(ctx.Request.Header, "", "    ")
+	redactedHeaders := redactSensitiveHeaders(ctx.Request.Header)
+	js, err := json.MarshalIndent(redactedHeaders, "", "    ")
 	if err != nil {
 		fmt.Errorf("json marshal has error :%s", err)
 	}
 	fmt.Println(string(js))
+}
+
+// redactSensitiveHeaders returns a copy of the given header map with sensitive header values redacted.
+func redactSensitiveHeaders(headers map[string][]string) map[string][]string {
+	sensitiveHeaders := []string{
+		"Authorization",
+		"Proxy-Authorization",
+		"Cookie",
+		"Set-Cookie",
+	}
+	redacted := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		redactedKey := false
+		for _, sh := range sensitiveHeaders {
+			if strings.EqualFold(k, sh) {
+				redactedKey = true
+				break
+			}
+		}
+		if redactedKey {
+			redacted[k] = []string{"REDACTED"}
+		} else {
+			redacted[k] = v
+		}
+	}
+	return redacted
 }


### PR DESCRIPTION
Potential fix for [https://github.com/kingofzihua/learn-go/security/code-scanning/1](https://github.com/kingofzihua/learn-go/security/code-scanning/1)

To fix the problem, we should ensure that sensitive header values are neither logged nor exposed in cleartext. A robust approach is to filter out headers known to contain sensitive data (for example, `Authorization`, `Cookie`, `Set-Cookie`, or any other custom headers you know are sensitive) before logging. The best fix is to marshal only non-sensitive headers, or at the least, to redact sensitive values. 

- In `web/gin/m3u.go`, only log a filtered set of headers, where sensitive keys are either omitted or replaced with a placeholder value (such as `"REDACTED"`).
- The code should include a function to process the headers and return a copy with sensitive values redacted. 
- The fix involves creating a new header map, copying non-sensitive values, and redacting the ones in a sensitive list before marshaling and logging.

We'll need to:
- Add a list of sensitive header names to check against (both canonical, e.g., `Authorization`, and case-insensitive comparisons).
- Replace lines 10–14 to filter/redact sensitive headers before marshaling/logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
